### PR TITLE
Fix setup issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ out/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.yarn/
 .pnpm-debug.log*
 .vercel
 *.tsbuildinfo

--- a/.mise/tasks/eth
+++ b/.mise/tasks/eth
@@ -3,4 +3,4 @@
 forge build
 forge test
 sleep 0.2 && mise run eth-deploy &
-just wagmi &
+yarn run wagmi generate &


### PR DESCRIPTION
Why:
* The `eth` Mise task relied on Justfile to generate the
  `wagmi.generated.ts`. Since we no longer have a Justile,
  the file was never generated, causing an error

How:
* Replacing the call to `just wagmi` with `yarn run wagmi generate`
* Adding a `.yarn` folder to the gitignore that appeared during a fresh
  install
