### PR TITLE
Update remappings to fix forge build

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -30,5 +30,6 @@ jobs:
       - name: Run Forge build
         run: |
           forge --version
+          forge soldeer update
           forge build --sizes
         id: build

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,8 @@
+@openzeppelin-contracts-5.0.2/=dependencies/@openzeppelin-contracts-5.0.2/
+@openzeppelin-contracts-upgradeable-5.2.0/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
 @openzeppelin-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.0.2/
+forge-std-1.9.5/=dependencies/forge-std-1.9.5/
 forge-std/=dependencies/forge-std-1.9.5/src/
+openzeppelin-foundry-upgrades-0.4.0/=dependencies/openzeppelin-foundry-upgrades-0.4.0/
 openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.4.0/src/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,8 +1,4 @@
-@openzeppelin-contracts-5.0.2/=dependencies/@openzeppelin-contracts-5.0.2/
-@openzeppelin-contracts-upgradeable-5.2.0/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
 @openzeppelin-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
 @openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.0.2/
-forge-std-1.9.5/=dependencies/forge-std-1.9.5/
 forge-std/=dependencies/forge-std-1.9.5/src/
-openzeppelin-foundry-upgrades-0.4.0/=dependencies/openzeppelin-foundry-upgrades-0.4.0/
 openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.4.0/src/

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,4 +1,4 @@
-@openzeppelin-contracts-5.0.2/=dependencies/@openzeppelin-contracts-5.0.2/
-@openzeppelin-contracts-upgradeable-5.2.0/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
-forge-std-1.9.5/=dependencies/forge-std-1.9.5/
-openzeppelin-foundry-upgrades-0.4.0/=dependencies/openzeppelin-foundry-upgrades-0.4.0/
+@openzeppelin-upgradeable/=dependencies/@openzeppelin-contracts-upgradeable-5.2.0/
+@openzeppelin/contracts/=dependencies/@openzeppelin-contracts-5.0.2/
+forge-std/=dependencies/forge-std-1.9.5/src/
+openzeppelin-foundry-upgrades/=dependencies/openzeppelin-foundry-upgrades-0.4.0/src/


### PR DESCRIPTION
Why:
* `remappings.txt` is using versioned remappings for dependencies but
  contracts use non-versioned imports so build fails

How:
* Updating `remappings.txt` to map non-versioned to versioned dependencies
